### PR TITLE
Update PDO assign requirement and config logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ CherryECAT is a tiny and beautiful, high real-time and low-jitter EtherCAT maste
 
 - **Slave**
 	- Must support COE
-	- Must support PDO assign
 	- Must support sdo complete access
 	- SII must have sync manager information
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -39,7 +39,6 @@ CherryECAT 是一个小而美的、高实时性、低抖动的 EtherCAT 主机�
 
 - 从站
 	- 必须支持 COE
-	- 必须支持 PDO assign
 	- 必须支持 sdo complete access
 	- SII 必须携带 sync manager 信息
 

--- a/src/ec_slave.c
+++ b/src/ec_slave.c
@@ -530,7 +530,7 @@ static int ec_slave_config(ec_master_t *master, ec_slave_t *slave)
         return ret;
     }
 
-    if (slave->config) {
+    if (slave->config && slave->sii.general.coe_details.enable_pdo_assign) {
         uint32_t data;
 
         /* Config PDO assignments for 0x1c12, 0x1c13


### PR DESCRIPTION
- Remove PDO assign requirement from README.
- Check enable_pdo_assign before configuring PDOs in ec_slave_config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PDO assignment now respects the device’s SII setting: assignment is performed only when explicitly enabled, preventing unintended PDO changes.

* **Documentation**
  * Updated README to remove the “Must support PDO assign” requirement in the Slave section.
  * Updated README_zh to remove the corresponding “必须支持 PDO assign” item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->