### PR TITLE
fix(dc_ref_clock): null pointer dereference in ec_master_find_dc_ref_clock

### DIFF
--- a/src/ec_slave.c
+++ b/src/ec_slave.c
@@ -906,9 +906,9 @@ static void ec_master_find_dc_ref_clock(ec_master_t *master)
     }
 
     ec_datagram_fpwr(&master->dc_ref_sync_datagram,
-                     ref ? ref->station_address : 0xffff, ESCREG_OF(ESCREG->SYS_TIME), ref->base_dc_range == EC_DC_64 ? 8 : 4);
+                     ref ? ref->station_address : 0xffff, ESCREG_OF(ESCREG->SYS_TIME), ref ? (ref->base_dc_range == EC_DC_64 ? 8 : 4) : 4);
     ec_datagram_frmw(&master->dc_all_sync_datagram,
-                     ref ? ref->station_address : 0xffff, ESCREG_OF(ESCREG->SYS_TIME), ref->base_dc_range == EC_DC_64 ? 8 : 4);
+                     ref ? ref->station_address : 0xffff, ESCREG_OF(ESCREG->SYS_TIME), ref ? (ref->base_dc_range == EC_DC_64 ? 8 : 4) : 4);
 }
 
 static void ec_master_calc_topology(ec_master_t *master)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential null-pointer crash in system time synchronization. The system now safely falls back to default values when handling edge cases, improving overall stability and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->