### PR TITLE
fix(sii): correct bitmask check in EEPROM error detection

### DIFF
--- a/src/ec_sii.c
+++ b/src/ec_sii.c
@@ -52,7 +52,7 @@ sii_check:
         return ret;
     }
 
-    if (EC_READ_U16(datagram->data) & ESC_EEPROM_CTRL_STAT_ERR_ACK_CMD_SHIFT) {
+    if (EC_READ_U16(datagram->data) & ESC_EEPROM_CTRL_STAT_ERR_ACK_CMD_MASK) {
         return -EC_ERR_SII;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error detection logic in EEPROM read operations to use the correct bit mask for error acknowledgment checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->