### PR TITLE
Fix calculation of remainder for DC start offset

### DIFF
--- a/src/ec_slave.c
+++ b/src/ec_slave.c
@@ -746,7 +746,7 @@ static int ec_slave_config(ec_slave_t *slave)
         }
 
         uint64_t dc_start_time;
-        uint32_t remainder = EC_DC_START_OFFSET / (slave->config->dc_sync[0].cycle_time + slave->config->dc_sync[1].cycle_time);
+        uint32_t remainder = EC_DC_START_OFFSET % (slave->config->dc_sync[0].cycle_time + slave->config->dc_sync[1].cycle_time);
 
         dc_start_time = ec_timestamp_get_time_ns() + EC_DC_START_OFFSET +
                         slave->config->dc_sync[0].cycle_time + slave->config->dc_sync[1].cycle_time - remainder +


### PR DESCRIPTION
应该是笔误，语义比较奇怪
虽然不太会影响加载但是确实是bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected DC start-time offset handling so timing calculations now use the proper remainder value, improving synchronization behavior.
  * Applied a minor formatting adjustment with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->